### PR TITLE
fix: minor bug in deregister route

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -381,7 +381,9 @@ router.post('/deregisterForEvent/:eventID', checkIfAuthenticated, async (req, re
 					$inc: {
 						member_count: -1,
 					},
-				}
+				}, {
+	    				new: true
+	    			}
 			).exec();
 
             if(team.member_count == 0){


### PR DESCRIPTION
By default, findOneAndUpdate() returns the document as it was before update was applied. With `{ new: true }`, findOneAndUpdate() will instead give you the object after update was applied.